### PR TITLE
포인트 히스토리 조회 비즈니스 로직 구현

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -56,6 +56,6 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.usePoint(id, amount);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -24,7 +24,7 @@ public class PointController {
     public UserPoint point(
             @PathVariable long id
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.selectPoint(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -34,7 +34,7 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        return pointService.getPointHistByUserId(id);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -11,6 +11,11 @@ import java.util.List;
 public class PointController {
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
+    private final PointService pointService;
+
+    public PointController(PointService pointService) {
+        this.pointService = pointService;
+    }
 
     /**
      * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
@@ -40,7 +45,7 @@ public class PointController {
             @PathVariable long id,
             @RequestBody long amount
     ) {
-        return new UserPoint(0, 0, 0);
+        return pointService.chargePoint(id, amount);
     }
 
     /**

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -4,6 +4,8 @@ import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class PointService {
     private final UserPointTable userPointTable;
@@ -15,12 +17,18 @@ public class PointService {
     }
 
     public UserPoint chargePoint(long id, long amount) {
+        // 포인트 히스토리 남기기
+        pointHistoryTable.insert(id,amount,TransactionType.CHARGE,System.currentTimeMillis());
+
         UserPoint userPoint = userPointTable.selectById(id);
         UserPoint updatedUserPoint = userPoint.charge(amount);
         return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
     }
 
     public UserPoint usePoint(long id, long amount) {
+        // 포인트 히스토리 남기기
+        pointHistoryTable.insert(id,amount,TransactionType.USE,System.currentTimeMillis());
+
         UserPoint userPoint = userPointTable.selectById(id);
         UserPoint updatedUserPoint = userPoint.use(amount);
         return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
@@ -28,5 +36,9 @@ public class PointService {
 
     public UserPoint selectPoint(long id) {
         return userPointTable.selectById(id);
+    }
+
+    public List<PointHistory> getPointHistByUserId(long id) {
+        return pointHistoryTable.selectAllByUserId(id);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,14 +1,17 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PointService {
     private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
 
-    public PointService(UserPointTable userPointTable) {
+    public PointService(UserPointTable userPointTable, PointHistoryTable pointHistoryTable) {
         this.userPointTable = userPointTable;
+        this.pointHistoryTable = pointHistoryTable;
     }
 
     public UserPoint chargePoint(long id, long amount) {
@@ -21,5 +24,9 @@ public class PointService {
         UserPoint userPoint = userPointTable.selectById(id);
         UserPoint updatedUserPoint = userPoint.use(amount);
         return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
+    }
+
+    public UserPoint selectPoint(long id) {
+        return userPointTable.selectById(id);
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -16,4 +16,10 @@ public class PointService {
         UserPoint updatedUserPoint = userPoint.charge(amount);
         return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
     }
+
+    public UserPoint usePoint(long id, long amount) {
+        UserPoint userPoint = userPointTable.selectById(id);
+        UserPoint updatedUserPoint = userPoint.use(amount);
+        return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
+    }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/PointService.java
@@ -1,0 +1,19 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.UserPointTable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PointService {
+    private final UserPointTable userPointTable;
+
+    public PointService(UserPointTable userPointTable) {
+        this.userPointTable = userPointTable;
+    }
+
+    public UserPoint chargePoint(long id, long amount) {
+        UserPoint userPoint = userPointTable.selectById(id);
+        UserPoint updatedUserPoint = userPoint.charge(amount);
+        return userPointTable.insertOrUpdate(id, updatedUserPoint.point());
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -22,4 +22,14 @@ public record UserPoint(
             throw new IllegalArgumentException("충전할 수 있는 최소 금액은 0 이상입니다.");
         }
     }
+
+    public UserPoint use(long amount) {
+        if(this.point > amount) {
+            return new UserPoint(this.id, this.point - amount, System.currentTimeMillis());
+        } else if (this.point == 0){
+            throw new IllegalArgumentException("포인트가 없습니다. 충전해주세요");
+        } else {
+            throw new IllegalArgumentException("포인트가 부족합니다. " + this.point + "이하로 사용가능합니다");
+        }
+    }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -5,8 +5,21 @@ public record UserPoint(
         long point,
         long updateMillis
 ) {
+    public UserPoint {
+        validate(id, point);
+    }
 
     public static UserPoint empty(long id) {
         return new UserPoint(id, 0, System.currentTimeMillis());
+    }
+
+    public UserPoint charge(long amount) {
+        return new UserPoint(this.id, this.point + amount, System.currentTimeMillis());
+    }
+
+    private static void validate(long id, long point){
+        if(point < 0) {
+            throw new IllegalArgumentException("충전할 수 있는 최소 금액은 0 이상입니다.");
+        }
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/UserPoint.java
+++ b/src/main/java/io/hhplus/tdd/point/UserPoint.java
@@ -18,6 +18,9 @@ public record UserPoint(
     }
 
     private static void validate(long id, long point){
+        if(id < 0) {
+            throw new IllegalArgumentException("id는 0L 이상입니다.");
+        }
         if(point < 0) {
             throw new IllegalArgumentException("충전할 수 있는 최소 금액은 0 이상입니다.");
         }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.database.PointHistoryTable;
 import io.hhplus.tdd.database.UserPointTable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ class PointServiceTest {
 
         // DB Mock
         UserPointTable mockRepository = mock(UserPointTable.class);
+        PointHistoryTable mockHistRepository = mock(PointHistoryTable.class);
 
         // Domain Mock
         // 조회된 객체 생성
@@ -26,7 +28,7 @@ class PointServiceTest {
         UserPoint mockUserPointAfter = mock(UserPoint.class);
 
         // service 설정
-        PointService pointService = new PointService(mockRepository);
+        PointService pointService = new PointService(mockRepository,mockHistRepository);
 
         // selectById 호출 -> mockUserPoint 반환
         when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
@@ -60,10 +62,11 @@ class PointServiceTest {
         long amount = -100L;
 
         //Mock 생성
-        UserPointTable mockRepository = mock(UserPointTable.class);
         UserPoint mockUserPoint = mock(UserPoint.class);
 
-        PointService pointService = new PointService(mockRepository);
+        UserPointTable mockRepository = mock(UserPointTable.class);
+        PointHistoryTable mockHistRepository = mock(PointHistoryTable.class);
+        PointService pointService = new PointService(mockRepository,mockHistRepository);
 
         //selectById 호출 -> mockUserPoint 반환
         when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
@@ -88,6 +91,7 @@ class PointServiceTest {
 
         // DB Mock
         UserPointTable mockRepository = mock(UserPointTable.class);
+        PointHistoryTable mockHistRepository = mock(PointHistoryTable.class);
 
         // Domain Mock
         // 조회된 객체를 가짜로 생성
@@ -96,7 +100,7 @@ class PointServiceTest {
         UserPoint mockUserPointAfter = mock(UserPoint.class);
 
         // service 설정
-        PointService pointService = new PointService(mockRepository);
+        PointService pointService = new PointService(mockRepository,mockHistRepository);
 
         // selectById 호출 -> mockUserPoint 반환
         when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
@@ -129,10 +133,11 @@ class PointServiceTest {
         long id = 1L;
         long amount = 300L;
 
-        UserPointTable mockRepository = mock(UserPointTable.class);
         UserPoint mockUserPoint = mock(UserPoint.class);
 
-        PointService pointService = new PointService(mockRepository);
+        UserPointTable mockRepository = mock(UserPointTable.class);
+        PointHistoryTable mockHistRepository = mock(PointHistoryTable.class);
+        PointService pointService = new PointService(mockRepository,mockHistRepository);
 
         //selectById 호출 -> mockUserPoint 반환
         when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
@@ -148,5 +153,36 @@ class PointServiceTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("잔액이 부족합니다.");
 
+    }
+
+    @Test
+    @DisplayName("포인트 조회 시, 유효한 ID이면 저장된 값/존재하지 않는 ID 이면 0을 조회한다.")
+    void selectPointById_ReturnPoint() {
+        //given
+        long id = 1L;
+        long amount = 200L;
+
+        UserPointTable mockRepository = mock(UserPointTable.class);
+        PointHistoryTable mockHistRepository = mock(PointHistoryTable.class);
+        PointService pointService = new PointService(mockRepository,mockHistRepository);
+
+        //유효한 id 1L 의 포인트는 200L
+        when(mockRepository.selectById(id)).thenReturn(new UserPoint(id, amount, System.currentTimeMillis()));
+
+        //존재하지 않는 id 50L의 포인트는 0
+        when(mockRepository.selectById(50L)).thenReturn(UserPoint.empty(50L));
+
+        //when
+        long selectedPoint = pointService.selectPoint(id).point();
+        long initPoint = pointService.selectPoint(50L).point();
+
+        //then
+        // 유효한 id
+        assertThat(selectedPoint).isEqualTo(amount);
+        verify(mockRepository).selectById(id);
+
+        // 존재하지 않는 id
+        assertThat(initPoint).isEqualTo(0L);
+        verify(mockRepository).selectById(50L);
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -1,0 +1,81 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.UserPointTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.*;
+
+class PointServiceTest {
+    @Test
+    @DisplayName("포인트 충전 시 DB조회 및 저장 호출을 검증한다")
+    void chargePoint_VerifyProcess() {
+        //given
+        long id = 1L;
+        long amount = 200L;
+
+        // DB Mock
+        UserPointTable mockRepository = mock(UserPointTable.class);
+
+        // Domain Mock
+        // 조회된 객체 생성
+        UserPoint mockUserPoint = mock(UserPoint.class);
+        // 포인트 충전 후 반환될 객체
+        UserPoint mockUserPointAfter = mock(UserPoint.class);
+
+        // service 설정
+        PointService pointService = new PointService(mockRepository);
+
+        // selectById 호출 -> mockUserPoint 반환
+        when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
+
+        // charge 호출 -> mockUserPointAfter 반환
+        when(mockUserPoint.charge(amount)).thenReturn(mockUserPointAfter);
+
+        // insertOrUpdate 호출 -> mockUserPointAfter 반환
+        when(mockRepository.insertOrUpdate(id, mockUserPointAfter.point()))
+                .thenReturn(mockUserPointAfter);
+
+        //when
+        UserPoint result = pointService.chargePoint(id, amount);
+
+        //then : 흐름 검증 (흐름 검증이라 값에 대한 검증은 하지 않음)
+        // selectById 가 호출 됐는지
+        verify(mockRepository).selectById(id);
+
+        // use 가 호출 됐는지
+        verify(mockUserPoint).charge(amount);
+
+        // insertOrUpdate 가 호출 됐는지
+        verify(mockRepository).insertOrUpdate(id, mockUserPointAfter.point());
+    }
+
+    @Test
+    @DisplayName("포인트 충전값이 0보다 작을 때 예외 처리를 검증한다.")
+    void chargePoint_VerifyException() {
+        //given
+        long id = 1L;
+        long amount = -100L;
+
+        //Mock 생성
+        UserPointTable mockRepository = mock(UserPointTable.class);
+        UserPoint mockUserPoint = mock(UserPoint.class);
+
+        PointService pointService = new PointService(mockRepository);
+
+        //selectById 호출 -> mockUserPoint 반환
+        when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
+
+        //charge 호출 -> 예외 반환
+        when(mockUserPoint.charge(amount)).thenThrow(new IllegalArgumentException("0이상 충전 가능"));
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> pointService.chargePoint(id,amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("0이상 충전 가능");
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/PointServiceTest.java
@@ -78,4 +78,75 @@ class PointServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("0이상 충전 가능");
     }
+
+    @Test
+    @DisplayName("포인트 사용 시 DB 조회 및 저장 호출을 검증한다.")
+    void usePoint_VerifyProcess() {
+        //given
+        long id = 1L;
+        long amount = 50L;
+
+        // DB Mock
+        UserPointTable mockRepository = mock(UserPointTable.class);
+
+        // Domain Mock
+        // 조회된 객체를 가짜로 생성
+        UserPoint mockUserPoint = mock(UserPoint.class);
+        // 포인트 사용 후 반환될 객체
+        UserPoint mockUserPointAfter = mock(UserPoint.class);
+
+        // service 설정
+        PointService pointService = new PointService(mockRepository);
+
+        // selectById 호출 -> mockUserPoint 반환
+        when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
+
+        // use 호출 -> mockUserPointAfter 반환
+        when(mockUserPoint.use(amount)).thenReturn(mockUserPointAfter);
+
+        // insertOrUpdate 호출 -> mockUserPointAfter 반환
+        when(mockRepository.insertOrUpdate(id, mockUserPointAfter.point()))
+                .thenReturn(mockUserPointAfter);
+
+        //when
+        UserPoint result = pointService.usePoint(id, amount);
+
+        //then : 흐름 검증 (흐름 검증이라 값에 대한 검증은 하지 않음)
+        // selectById 가 호출 됐는지
+        verify(mockRepository).selectById(id);
+
+        // use 가 호출 됐는지
+        verify(mockUserPoint).use(amount);
+
+        // insertOrUpdate 가 호출 됐는지
+        verify(mockRepository).insertOrUpdate(id, mockUserPointAfter.point());
+    }
+
+    @Test
+    @DisplayName("포인트가 0이거나 사용할 값보다 작을 때 예외 처리를 검증한다.")
+    void usePoint_VerifyException() {
+        //given
+        long id = 1L;
+        long amount = 300L;
+
+        UserPointTable mockRepository = mock(UserPointTable.class);
+        UserPoint mockUserPoint = mock(UserPoint.class);
+
+        PointService pointService = new PointService(mockRepository);
+
+        //selectById 호출 -> mockUserPoint 반환
+        when(mockRepository.selectById(id)).thenReturn(mockUserPoint);
+
+        //use 호출 -> 예외 반환
+        when(mockUserPoint.use(amount)).thenThrow(new IllegalStateException("잔액이 부족합니다."));
+
+        //when
+
+
+        //then
+        assertThatThrownBy(() -> pointService.usePoint(id,amount))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("잔액이 부족합니다.");
+
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointTest.java
@@ -1,0 +1,52 @@
+package io.hhplus.tdd.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserPointTest {
+    @Test
+    @DisplayName("포인트 누적 값을 계산한다.")
+    void calculate_sumPoint() {
+        //given
+        long id = 1L;
+
+        //시나리오 : 100L 포인트가 있는데 200L를 충전했을 때 누적 값을 계산
+        UserPoint userPoint = new UserPoint(id, 100L, System.currentTimeMillis());
+
+        //when
+        long point = userPoint.charge(200L).point(); // 결과 : 300L
+
+        //then
+        assertThat(point).isEqualTo(300L);
+    }
+
+    @Test
+    @DisplayName("처음 포인트 충전이면 충전값을 반환한다.")
+    void chargePoint() {
+        //given
+        //시나리오 : 처음 100L 포인트를 충전했을 때 100L 포인트 반환
+        UserPoint userPoint = UserPoint.empty(1L);
+
+        //when
+        long point = userPoint.charge(100L).point(); // 결과 : 100L
+
+        //then
+        assertThat(point).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("0보다 작은 값 충전시 예외처리한다.")
+    void chargeMinusPoint_Exception() {
+        //given
+        //시나리오 : 0보다 작은 -100L 포인트를 충전시도 했을 때 예외 반환
+        UserPoint userPoint = UserPoint.empty(1L);
+
+        //when
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> userPoint.charge(-100L).point());
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointTest.java
@@ -49,4 +49,38 @@ class UserPointTest {
         //then
         assertThrows(IllegalArgumentException.class, () -> userPoint.charge(-100L).point());
     }
+
+    @Test
+    @DisplayName("포인트 사용하면 나머지 값을 반환한다.")
+    void usePoint_ReturnRemainder() {
+        //given
+        long id = 1L;
+
+        //시나리오 : 처음 300L 포인트를 있을 때 200L 포인트 사용 -> 나머지 값 100L 반환
+        UserPoint userPoint = new UserPoint(id, 300L, System.currentTimeMillis());
+
+        //when
+        long point = userPoint.use(200L).point(); // 결과 : 100L
+
+        // then
+        assertThat(point).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("포인트가 0이거나 사용할 값보다 작으면 예외처리한다.")
+    void useMinusPoint_ReturnException() {
+        //given
+        //시나리오 : 100L 포인트가 있을 때 200L 포인트 사용 -> -100L 이 되므로 예외처리
+        UserPoint userPoint1 = new UserPoint(1L, 100L, System.currentTimeMillis());
+
+        //시나리오 : 0L 포인트가 있을 때 50L 포인트 사용 -> -50L 이 되므로 예외처리
+        UserPoint userPoint2 = new UserPoint(2L, 0L, System.currentTimeMillis());
+
+        //when
+
+
+        // then
+        assertThrows(IllegalArgumentException.class, () -> userPoint1.use(200L).point());
+        assertThrows(IllegalArgumentException.class, () -> userPoint2.use(50L).point());
+    }
 }

--- a/src/test/java/io/hhplus/tdd/point/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/UserPointTest.java
@@ -83,4 +83,16 @@ class UserPointTest {
         assertThrows(IllegalArgumentException.class, () -> userPoint1.use(200L).point());
         assertThrows(IllegalArgumentException.class, () -> userPoint2.use(50L).point());
     }
+
+    @Test
+    @DisplayName("포인트 조회 시, id에 0보다 작은 값이 들어가면 예외처리한다.")
+    void selectPointByNull_ReturnException() {
+        //given
+
+        //when
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> UserPoint.empty(-1L));
+
+    }
 }


### PR DESCRIPTION
### **커밋 설명**
포인트 히스토리 조회 (2185bfc)
- id를 이용해 사용자의 포인트 히스토리를 조회합니다.
- 히스토리가 없는 경우 빈 배열을 반환합니다.
- 리팩토링과 동시성 제어는 현재 진행중입니다. 

의사결정 흐름
- ID로 사용자 조회를 하여 포인트 히스토리를 반환했습니다.
- 포인트 충전과 사용 시 히스토리를 남기기 위한 처리를 포함시켰습니다.
---

### **리뷰 받고 싶은 내용(질문)**
- 커밋:PointServiceTest
- 내용:selectPointHistory_ReturnEmpty()에서 빈배열 체크하는 것은 유의미한 테스트케이스 인지 검토 부탁드립니다. 

- 커밋:PointServiceTest
- 내용:히스토리 를 안쓰는 경우에도 mockHistRepository mock을 만들어주어야하는지 리팩토링 방법이 있는지 검토 부탁드립니다.

- 커밋:PointServiceTest
- 내용:Repository mock을 만들고 service 설정하는 부분이 매 테스트 케이스 마다 반복되는데 리팩토링 방법이 있는지 검토 부탁드립니다.
---

### **과제 셀프 피드백**
- PR을 올릴 때 commit 분리를 잘못했다.
- 리팩토링을 못했다.
